### PR TITLE
hooks: Add --spoof-apple/-S flag to patch isApple for allowed binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Options:
   --cdhash, -c TEXT    cdhash of executable to allow (can be specified multiple times, merged with ~/.amfidont/cdhashes)
   --verbose, -v        enable verbose output
   --allow-all          allow all validations to pass
+  --spoof-apple, -S    patch isApple to return true for allowed binaries
   --install-completion Install completion for the current shell.
   --show-completion    Show completion for the current shell, to copy it or customize the installation.
   --help               Show this message and exit.
@@ -61,7 +62,16 @@ Commands:
     sudo amfidont daemon --verbose
     ```
 
-4. Stop foreground mode with `Ctrl-C` (this detaches `amfidont` and leaves `amfid` running).
+4. (Optional) Spoof allowed binaries as Apple-signed:
+
+    ```shell
+    sudo amfidont --spoof-apple --verbose
+    ```
+
+    For example, this can be used to run self-signed `arm64e` binaries without
+    setting the `arm64e_preview_abi` boot argument.
+
+5. Stop foreground mode with `Ctrl-C` (this detaches `amfidont` and leaves `amfid` running).
 
 ## Inner implementation details
 
@@ -78,6 +88,15 @@ Commands:
   - validation state (`isValid`)
 - If the validator is invalid but the path/cdhash matches configured allow-rules,
   the return register is patched to success and execution continues.
+- When `--spoof-apple` is enabled, an additional breakpoint is set on:
+
+```none
+-[AMFIPathValidator_macos isApple]
+```
+
+  This patches `isApple` to return true for allowed binaries, making them appear
+  Apple-signed. For example, this allows running self-signed `arm64e` binaries
+  without the `arm64e_preview_abi` boot argument.
 - Persistent configuration is stored in:
   - `~/.amfidont/paths`
   - `~/.amfidont/cdhashes`

--- a/amfidont/__main__.py
+++ b/amfidont/__main__.py
@@ -46,6 +46,13 @@ def main(
             '--allow-all',
             help='allow all validations to pass'
         )] = False,
+    spoof_apple: Annotated[
+        bool,
+        typer.Option(
+            '-S',
+            '--spoof-apple',
+            help='patch isApple to return true for allowed binaries'
+        )] = False,
 ) -> None:
     """
     Run bypass mode by default when no subcommand is selected.
@@ -55,9 +62,10 @@ def main(
     :param cdhashes: Optional cdhashes to allow.
     :param verbose: Enables verbose runtime output.
     :param allow_all: Enables unconditional validation bypass for all binaries.
+    :param spoof_apple: Patches isApple to return true for allowed binaries.
     """
     if ctx.invoked_subcommand is None:
-        run_bypass(paths=paths, cdhashes=cdhashes, verbose=verbose, allow_all=allow_all)
+        run_bypass(paths=paths, cdhashes=cdhashes, verbose=verbose, allow_all=allow_all, spoof_apple=spoof_apple)
 
 
 @cli.command()
@@ -89,6 +97,13 @@ def daemon(
             '--allow-all',
             help='allow all validations to pass'
         )] = False,
+    spoof_apple: Annotated[
+        bool,
+        typer.Option(
+            '-S',
+            '--spoof-apple',
+            help='patch isApple to return true for allowed binaries'
+        )] = False,
 ) -> None:
     """
     Start amfidont in daemon mode.
@@ -97,8 +112,9 @@ def daemon(
     :param cdhashes: Optional cdhashes to allow.
     :param verbose: Enables verbose runtime output.
     :param allow_all: Enables unconditional validation bypass for all binaries.
+    :param spoof_apple: Patches isApple to return true for allowed binaries.
     """
-    start_daemon(paths=paths, cdhashes=cdhashes, verbose=verbose, allow_all=allow_all)
+    start_daemon(paths=paths, cdhashes=cdhashes, verbose=verbose, allow_all=allow_all, spoof_apple=spoof_apple)
 
 
 @cli.command("add-path")

--- a/amfidont/bypass_runtime.py
+++ b/amfidont/bypass_runtime.py
@@ -80,6 +80,54 @@ def validate_hook(
             pprint(result)
 
 
+def is_apple_hook(
+    target: lldb.SBTarget,
+    thread: lldb.SBThread,
+    paths: Set[str],
+    cdhashes: Set[str],
+    verbose: bool = False,
+    allow_all: bool = False,
+) -> None:
+    """
+    Patch isApple to return true when the binary matches configured allow-rules.
+
+    :param target: LLDB target attached to `amfid`.
+    :param thread: The stopped thread at the isApple breakpoint.
+    :param paths: Allowed executable path prefixes.
+    :param cdhashes: Allowed cdhash values.
+    :param verbose: Enables additional runtime logging.
+    :param allow_all: Forces all isApple checks to return true regardless of path/cdhash.
+    """
+    ret_reg, self_reg = registers_for_target(target)
+
+    frame = thread.frames[0]
+    validator = frame.reg[self_reg].value
+
+    thread.StepOutOfFrame(frame)
+
+    ret = thread.frames[0].reg[ret_reg]
+    result = dump_validator(target, validator)
+
+    if allow_all:
+        if verbose:
+            print(f"isApple patched due to --allow-all: {result['path']}")
+        ret.SetValueFromCString("1")
+        return
+
+    if result["cdhash"] in cdhashes:
+        if verbose:
+            print(f"isApple patched due to cdhash {result['cdhash']}")
+        ret.SetValueFromCString("1")
+        return
+
+    for path in paths:
+        if result["path"].startswith(path):
+            if verbose:
+                print(f"isApple patched due to path {result['path']}")
+            ret.SetValueFromCString("1")
+            return
+
+
 def dump_validator(target: lldb.SBTarget, validator: str) -> Dict[str, Union[str, bool]]:
     """
     Read path/cdhash/validity fields from an `AMFIPathValidator` object.
@@ -147,6 +195,7 @@ def bypass_loop(
     cdhashes: Optional[List[str]] = None,
     verbose: bool = False,
     allow_all: bool = False,
+    spoof_apple: bool = False,
 ) -> None:
     """
     Main runtime loop that continues `amfid`, reloads config changes, and patches
@@ -158,6 +207,7 @@ def bypass_loop(
     :param cdhashes: Optional allowlisted cdhash values.
     :param verbose: Enables verbose runtime logging.
     :param allow_all: Forces all validations to pass regardless of config.
+    :param spoof_apple: Patches isApple to return true for allowed binaries.
     """
     cli_paths = set(paths or [])
     cli_cdhashes = set(cdhashes or [])
@@ -194,14 +244,25 @@ def bypass_loop(
 
         thread = get_stopped_thread(process, lldb.eStopReasonBreakpoint)
         if thread:
-            validate_hook(
-                target,
-                thread,
-                allowed_paths,
-                allowed_cdhashes,
-                verbose=verbose,
-                allow_all=allow_all,
-            )
+            func_name = thread.frames[0].GetFunctionName()
+            if spoof_apple and "isApple" in func_name:
+                is_apple_hook(
+                    target,
+                    thread,
+                    allowed_paths,
+                    allowed_cdhashes,
+                    verbose=verbose,
+                    allow_all=allow_all,
+                )
+            else:
+                validate_hook(
+                    target,
+                    thread,
+                    allowed_paths,
+                    allowed_cdhashes,
+                    verbose=verbose,
+                    allow_all=allow_all,
+                )
 
 
 def run_bypass(
@@ -209,6 +270,7 @@ def run_bypass(
     cdhashes: Optional[List[str]] = None,
     verbose: bool = False,
     allow_all: bool = False,
+    spoof_apple: bool = False,
 ) -> None:
     """
     Run the foreground bypass loop against `amfid`.
@@ -217,6 +279,7 @@ def run_bypass(
     :param cdhashes: Optional cdhashes supplied by CLI.
     :param verbose: Enables informative runtime logging.
     :param allow_all: Forces all validations to pass regardless of path/cdhash.
+    :param spoof_apple: Patches isApple to return true for allowed binaries.
     """
     debugger = lldb.SBDebugger.Create()
     debugger.SetAsync(False)
@@ -233,13 +296,16 @@ def run_bypass(
         print(f"Attached to {AMFID_PATH}")
 
     target.BreakpointCreateByName("-[AMFIPathValidator_macos validateWithError:]")
+    if spoof_apple:
+        target.BreakpointCreateByName("-[AMFIPathValidator_macos isApple]")
     if verbose:
-        print("Installed validateWithError breakpoint")
+        breakpoints = "validateWithError and isApple" if spoof_apple else "validateWithError"
+        print(f"Installed {breakpoints} breakpoints")
 
     try:
         thread = threading.Thread(
             target=bypass_loop,
-            args=(process, target, paths, cdhashes, verbose, allow_all),
+            args=(process, target, paths, cdhashes, verbose, allow_all, spoof_apple),
         )
         thread.daemon = True
         thread.start()

--- a/amfidont/daemon_runtime.py
+++ b/amfidont/daemon_runtime.py
@@ -8,6 +8,7 @@ def start_daemon(
     cdhashes: Optional[List[str]] = None,
     verbose: bool = False,
     allow_all: bool = False,
+    spoof_apple: bool = False,
 ) -> None:
     """
     Start amfidont in a detached background process.
@@ -16,12 +17,15 @@ def start_daemon(
     :param cdhashes: Optional cdhashes to pass to the child process.
     :param verbose: Enables verbose startup logging and forwards `--verbose` to child.
     :param allow_all: Forwards unconditional validation bypass mode to child.
+    :param spoof_apple: Forwards isApple spoofing mode to child.
     """
     child_args = [sys.executable, "-m", "amfidont"]
     if verbose:
         child_args.append("--verbose")
     if allow_all:
         child_args.append("--allow-all")
+    if spoof_apple:
+        child_args.append("--spoof-apple")
     for path in paths or []:
         child_args.extend(["--path", path])
     for cdhash in cdhashes or []:


### PR DESCRIPTION
When amfid validates a binary, it also checks whether the binary is Apple-signed via the isApple method. This is relevant for many different usecases, for instance, running self-signed `arm64e` binary currently requires setting the `arm64e_preview_abi` boot argument. With `--spoof-apple`, `amfidont` patches `isApple` to return true for allowed binaries, bypassing this restriction without needing to set any boot args.

The isApple breakpoint and hook are only installed when the flag is explicitly enabled.

<!---

Thanks for opening a PR on amfidont!

Please review the CONTRIBUTING.md first regarding the linters we use and how
do we enforce them.

-->

## For community

⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
